### PR TITLE
Fix: Ensure main info section occupies full width

### DIFF
--- a/src/layout/FrontEnd/informationtab/daily_forecast.py
+++ b/src/layout/FrontEnd/informationtab/daily_forecast.py
@@ -72,4 +72,5 @@ class DailyForecast:
             border_radius=15,
             padding=20,
             content=self.createHourlyForecast(),
+            expand=True,
         )

--- a/src/ui/weather_view.py
+++ b/src/ui/weather_view.py
@@ -41,7 +41,7 @@ class WeatherView:
         if state_manager:
             state_manager.register_observer("theme_event", self.handle_theme_change)
 
-        self.info_container = ft.Container(content=ft.Text("Caricamento...", color=self.text_color)) # Apply initial text color
+        self.info_container = ft.Container(content=ft.Text("Caricamento...", color=self.text_color), expand=True) # Apply initial text color
         self.weekly_container = ft.Container()
         self.chart_container = ft.Container()
         self.air_pollution_container = ft.Container()
@@ -213,6 +213,7 @@ class WeatherView:
                 air_condition.build(),
             ])
         )
+        self.info_container.expand = True
 
     async def _update_weekly_forecast(self) -> None:
         """Frontend: Updates weekly forecast UI"""


### PR DESCRIPTION
The main information container (`info_container` in `WeatherView`), which includes the current weather, hourly forecast, and air conditions, was not expanding to the full width of its parent layout in `app.py`.

This was resolved by:
1. Setting `expand=True` for `WeatherView.info_container` during its initialization and when its content is updated. This allows the container to fill the space provided by its parent wrapper in `app.py`.

The `WeatherCard` component, which forms the content of `info_container`, already had `expand=True`. The layout in `app.py` uses a `ResponsiveRow` with `col={'xs': 12}` for the wrapper of `info_container`, ensuring the wrapper itself is allocated the full width.

These changes ensure the entire main information section, including the hourly forecast, now correctly utilizes the available width.